### PR TITLE
isFullWidth has been deprecated

### DIFF
--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -23,10 +23,6 @@ interface InputOptions {
    * errorBorderColor = "red.500"
    */
   errorBorderColor?: string
-  /**
-   * If `true`, the input element will span the full width of its parent
-   */
-  isFullWidth?: boolean
 }
 
 type Omitted = "disabled" | "required" | "readOnly" | "size"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [x] Other (please describe):
isFullWidth option is deprecated for Input

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #2357

## What is the new behavior?

<!-- PleThease describe the behavior or changes that are being added by this PR. -->

- The `isFullWidth` option does not appear anymore in the documentation of `Input` component
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
